### PR TITLE
Fixes issue #6

### DIFF
--- a/fedex/services/track_service.py
+++ b/fedex/services/track_service.py
@@ -42,6 +42,7 @@ class FedexTrackRequest(FedexBaseService):
         super(FedexTrackRequest, self).__init__(self._config_obj, 
                                                 'TrackService_v4.wsdl',
                                                 *args, **kwargs)
+        self.IncludeDetailedScans = False
         
     def _prepare_wsdl_objects(self):
         """
@@ -80,6 +81,7 @@ class FedexTrackRequest(FedexBaseService):
                                         ClientDetail=self.ClientDetail,
                                         TransactionDetail=self.TransactionDetail,
                                         Version=self.VersionId,
+                                        IncludeDetailedScans=self.IncludeDetailedScans,
                                         PackageIdentifier=self.TrackPackageIdentifier)
 
         return response


### PR DESCRIPTION
This change allows one to set track.IncludeDetailedScans = True in client
software to get the full tracking history on delivered packages, by default you
only get the last scan.
