### PR TITLE
Adding missing GeographicCoordinates object to locations service

### DIFF
--- a/fedex/services/location_service.py
+++ b/fedex/services/location_service.py
@@ -52,6 +52,9 @@ class FedexSearchLocationRequest(FedexBaseService):
         self.SortDetail = None
         """@ivar: Holds the LocationSortDetail WSDL object."""
 
+        self.GeographicCoordinates = None
+        """@ivar: Holds the LocationSortDetail WSDL object."""
+
         super(FedexSearchLocationRequest, self).__init__(
                 self._config_obj, 'LocationsService_v9.wsdl', *args, **kwargs)
 
@@ -65,6 +68,7 @@ class FedexSearchLocationRequest(FedexBaseService):
         self.Constraints = self.create_wsdl_object_of_type('SearchLocationConstraints')
         self.Address = self.create_wsdl_object_of_type('Address')
         self.LocationsSearchCriterion = 'ADDRESS'
+        self.GeographicCoordinates = None
         self.SortDetail = self.create_wsdl_object_of_type('LocationSortDetail')
 
     def _assemble_and_send_request(self):
@@ -94,4 +98,5 @@ class FedexSearchLocationRequest(FedexBaseService):
                 MultipleMatchesAction=self.MultipleMatchesAction,
                 Constraints=self.Constraints,
                 Address=self.Address,
-                SortDetail=self.SortDetail)
+                SortDetail=self.SortDetail,
+                GeographicCoordinates=self.GeographicCoordinates)

--- a/fedex/services/location_service.py
+++ b/fedex/services/location_service.py
@@ -53,7 +53,7 @@ class FedexSearchLocationRequest(FedexBaseService):
         """@ivar: Holds the LocationSortDetail WSDL object."""
 
         self.GeographicCoordinates = None
-        """@ivar: Holds the LocationSortDetail WSDL object."""
+        """@ivar: Holds the GeographicCoordinates WSDL object."""
 
         super(FedexSearchLocationRequest, self).__init__(
                 self._config_obj, 'LocationsService_v9.wsdl', *args, **kwargs)

--- a/tests/test_location_service.py
+++ b/tests/test_location_service.py
@@ -49,6 +49,8 @@ class SearchLocationServiceTests(unittest.TestCase):
         location_request.Address.CountryCode = 'US'
         
     def test_location_coordinates_search(self):
+        # Test search by geo coordinates
+        # https://www.fedex.com/us/developer/webhelp/ws/2020/US/FedEx_WebServices_2020_Developer_Guide.htm#t=wsdvg%2FLocation_Request_Coding_Details.htm
         
         location_request = FedexSearchLocationRequest(CONFIG_OBJ)
         location_request.LocationsSearchCriterion = 'GEOGRAPHIC_COORDINATES'

--- a/tests/test_location_service.py
+++ b/tests/test_location_service.py
@@ -47,7 +47,16 @@ class SearchLocationServiceTests(unittest.TestCase):
         location_request = FedexSearchLocationRequest(CONFIG_OBJ)
         location_request.Address.PostalCode = '38119'
         location_request.Address.CountryCode = 'US'
+        
+    def test_location_coordinates_search(self):
+        
+        location_request = FedexSearchLocationRequest(CONFIG_OBJ)
+        location_request.LocationsSearchCriterion = 'GEOGRAPHIC_COORDINATES'
+        location_request.Address.CountryCode = 'US'
+        location_request.GeographicCoordinates = '34.074866096127096-118.40365442768258/'
 
+        location_request.send_request()
+        assert location_request.response.HighestSeverity == 'SUCCESS'
 
 if __name__ == "__main__":
     logging.basicConfig(stream=sys.stdout, level=logging.INFO)


### PR DESCRIPTION
The GeographicCoordinates object appears in the locations wsdl, but the object is missing in the locations service module. After adding this object according to the existing patterns, my request for a location search based on geographic coordinates worked.
