### PR TITLE
Update dependency to support suds-community

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-suds-jurko
+suds-community

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-suds-community
+suds-community==1.0.0

--- a/setup.py
+++ b/setup.py
@@ -34,5 +34,5 @@ setup(name='fedex',
       classifiers=CLASSIFIERS,
       keywords=KEYWORDS,
       requires=['suds'],
-      install_requires=['suds-jurko'],
+      install_requires=['suds-community'],
       )


### PR DESCRIPTION
This PR attempts to resolve issue #158 

While building with the latest version of fedex our ci/cd process breaks while attempting to install the dependency `suds-jurko`. 

```
ERROR: Command errored out with exit status 1:
     command: /usr/bin/python3 -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-i40r_jb8/suds-jurko/setup.py'"'"'; __file__='"'"'/tmp/pip-install-i40r_jb8/suds-jurko/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-install-i40r_jb8/suds-jurko/pip-egg-info
         cwd: /tmp/pip-install-i40r_jb8/suds-jurko/
    Complete output (1 lines):
    error in suds-jurko setup command: use_2to3 is invalid.
 ```
 
Upon further examination it turns out that python's setuptools drops support for 2to3 in version [v.58.0.0](https://setuptools.pypa.io/en/latest/history.html#v58-0-0). In order to correct this it is recommended to switch to the new and actively maintained package [suds-community](https://github.com/suds-community/suds) which already has resolved this problem [HERE](https://github.com/suds-community/suds/issues/57). 

Closes #158 
 
 I have also opted to pin this dependency for future cases where the project can be more intentional with the versions expected.