### PR TITLE
docs: Fix a few typos

### DIFF
--- a/epydoc_source/docs/1.0.0/epydoc.js
+++ b/epydoc_source/docs/1.0.0/epydoc.js
@@ -22,7 +22,7 @@ function toggle_private() {
           }
         }
         // Update all table rows containing private objects.  Note, we
-        // use "" instead of "block" becaue IE & firefox disagree on what
+        // use "" instead of "block" because IE & firefox disagree on what
         // this should be (block vs table-row), and "" just gives the
         // default for both browsers.
         var elts = document.getElementsByTagName("tr");

--- a/epydoc_source/docs/2.3.0/epydoc.js
+++ b/epydoc_source/docs/2.3.0/epydoc.js
@@ -22,7 +22,7 @@ function toggle_private() {
           }
         }
         // Update all table rows containing private objects.  Note, we
-        // use "" instead of "block" becaue IE & firefox disagree on what
+        // use "" instead of "block" because IE & firefox disagree on what
         // this should be (block vs table-row), and "" just gives the
         // default for both browsers.
         var elts = document.getElementsByTagName("tr");

--- a/tests/test_pickup_service.py
+++ b/tests/test_pickup_service.py
@@ -22,7 +22,7 @@ logging.getLogger('fedex').setLevel(logging.INFO)
 @unittest.skipIf(not CONFIG_OBJ.account_number, "No credentials provided.")
 class FedexCreatePickupRequestTests(unittest.TestCase):
     """
-    These tests verify that the pikckup service WSDL is in good shape.
+    These tests verify that the pickup service WSDL is in good shape.
     """
 
     def setUp(self):


### PR DESCRIPTION
There are small typos in:
- epydoc_source/docs/1.0.0/epydoc.js
- epydoc_source/docs/2.3.0/epydoc.js
- tests/test_pickup_service.py

Fixes:
- Should read `because` rather than `becaue`.
- Should read `pickup` rather than `pikckup`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md